### PR TITLE
Add networked powerup effects and player speed modifiers

### DIFF
--- a/Assets/Scripts/PuckPhysics.cs
+++ b/Assets/Scripts/PuckPhysics.cs
@@ -5,7 +5,7 @@ public class PuckPhysics : NetworkBehaviour
 {
   public static PuckPhysics Singleton;
   private ulong m_lastPlayerHit;
-
+  
   private void Awake()
   {
     if (Singleton == null)
@@ -25,7 +25,7 @@ public class PuckPhysics : NetworkBehaviour
 
     if (collision.gameObject.CompareTag("Powerup"))
     {
-      PowerupManager.Singleton.TiggerPowerupHit(
+      PowerupManager.Singleton.NetworkPowerupHit_Rpc(
         m_lastPlayerHit,
         collision.transform.parent.GetComponent<NetworkObject>().NetworkObjectId
       );


### PR DESCRIPTION
Introduces networked handling of powerup effects via NetworkPowerupHit_Rpc, applying and resetting effects like grow, shrink, and slow on players. Player speed effect variables are added to NetworkPlayer, and mouse delta calculations now account for these modifiers. Updates PuckPhysics to use the new networked powerup hit method.