### PR TITLE
Add puck respawn points and update goal logic

### DIFF
--- a/Assets/Prefabs/UI.prefab
+++ b/Assets/Prefabs/UI.prefab
@@ -684,16 +684,17 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &5359429716029559065
-RectTransform:
+--- !u!4 &5359429716029559065
+Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1695661078354528022}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 730, y: -358.71014, z: -24.658855}
+  m_LocalScale: {x: 1.823362, y: 1.823362, z: 1.823362}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 923700775061305836}
@@ -703,11 +704,6 @@ RectTransform:
   - {fileID: 5456208276855146912}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 2000, y: 1000}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &3444524386268432126
 GameObject:
   m_ObjectHideFlags: 0
@@ -725,7 +721,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &6135814748606989373
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GoalTest.unity
+++ b/Assets/Scenes/GoalTest.unity
@@ -255,6 +255,77 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 17897845}
   m_CullTransparentMesh: 1
+--- !u!1 &101070161
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 101070164}
+  - component: {fileID: 101070162}
+  - component: {fileID: 101070163}
+  m_Layer: 0
+  m_Name: GameManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &101070162
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 101070161}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.Netcode.Runtime::Unity.Netcode.NetworkObject
+  GlobalObjectIdHash: 4040042704
+  InScenePlacedSourceGlobalObjectIdHash: 0
+  DeferredDespawnTick: 0
+  Ownership: 1
+  AlwaysReplicateAsRoot: 0
+  SynchronizeTransform: 0
+  ActiveSceneSynchronization: 0
+  SceneMigrationSynchronization: 0
+  SpawnWithObservers: 1
+  DontDestroyWithOwner: 0
+  AutoObjectParentSync: 1
+  SyncOwnerTransformWhenParented: 1
+  AllowOwnerToParent: 0
+--- !u!114 &101070163
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 101070161}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 387773fa509d556439ae0e503ee0539e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::GameManager
+  ShowTopMostFoldoutHeaderGroup: 1
+--- !u!4 &101070164
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 101070161}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5803.4624, y: 0, z: 23567.857}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &294939834
 GameObject:
   m_ObjectHideFlags: 0
@@ -597,7 +668,7 @@ Transform:
   m_GameObject: {fileID: 405582448}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -11.72}
+  m_LocalPosition: {x: 0, y: 0, z: -13.19}
   m_LocalScale: {x: 0.25, y: 1, z: 0.25}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -679,6 +750,95 @@ MonoBehaviour:
   m_limit_x: {fileID: 0}
   m_limit_z: {fileID: 0}
   m_limit_center: {fileID: 0}
+--- !u!1 &459272128
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 459272131}
+  - component: {fileID: 459272130}
+  - component: {fileID: 459272129}
+  m_Layer: 0
+  m_Name: puckRespawnPlayer1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 2147483647
+  m_IsActive: 1
+--- !u!23 &459272129
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 459272128}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &459272130
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 459272128}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &459272131
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 459272128}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.0000001192093, z: -4}
+  m_LocalScale: {x: 0.25, y: 1, z: 0.25}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &491355802
 GameObject:
   m_ObjectHideFlags: 0
@@ -1373,7 +1533,7 @@ Transform:
   m_GameObject: {fileID: 1164901691}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 5.5, y: 0, z: -4.83}
+  m_LocalPosition: {x: 6.729, y: 0, z: -4.83}
   m_LocalScale: {x: 0.25, y: 1, z: 0.25}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1794,7 +1954,7 @@ Transform:
   m_GameObject: {fileID: 1619756995}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -2}
+  m_LocalPosition: {x: 0, y: 0, z: -0.138}
   m_LocalScale: {x: 0.25, y: 1, z: 0.25}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1808,9 +1968,49 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1320581347}
     m_Modifications:
+    - target: {fileID: 439779749247802129, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -284.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 439779749247802129, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 205.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 923700775061305836, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -397
+      objectReference: {fileID: 0}
+    - target: {fileID: 923700775061305836, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 204
+      objectReference: {fileID: 0}
     - target: {fileID: 1695661078354528022, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
       propertyPath: m_Name
       value: UI (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1795282257280383552, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 101070163}
+    - target: {fileID: 1795282257280383552, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Recommencer
+      objectReference: {fileID: 0}
+    - target: {fileID: 2670343164161320788, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 101070163}
+    - target: {fileID: 2670343164161320788, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Recommencer
+      objectReference: {fileID: 0}
+    - target: {fileID: 3444524386268432126, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4590882411478817734, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5359429716029559065, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
       propertyPath: m_Pivot.x
@@ -1904,13 +2104,25 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6135814748606989373, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 1500
+      objectReference: {fileID: 0}
+    - target: {fileID: 7711342846431240792, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 1500
+      objectReference: {fileID: 0}
+    - target: {fileID: 8302584040310733622, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
---- !u!224 &1654402670 stripped
-RectTransform:
+--- !u!4 &1654402670 stripped
+Transform:
   m_CorrespondingSourceObject: {fileID: 5359429716029559065, guid: c01573ed9e4f7d04aa9225cca9175751, type: 3}
   m_PrefabInstance: {fileID: 1654402669}
   m_PrefabAsset: {fileID: 0}
@@ -2368,6 +2580,95 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2002501184}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &2012503783
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2012503786}
+  - component: {fileID: 2012503785}
+  - component: {fileID: 2012503784}
+  m_Layer: 0
+  m_Name: puckRespawnPlayer2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 2147483647
+  m_IsActive: 1
+--- !u!23 &2012503784
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2012503783}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &2012503785
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2012503783}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &2012503786
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2012503783}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.0000001192093, z: 4}
+  m_LocalScale: {x: 0.25, y: 1, z: 0.25}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2032778698
 GameObject:
   m_ObjectHideFlags: 0
@@ -2705,18 +3006,23 @@ MonoBehaviour:
   thrust: 20
   Goal1: {fileID: 1763252990}
   Goal2: {fileID: 1763252991}
+  puckRespawnPlayer1: {fileID: 459272128}
+  puckRespawnPlayer2: {fileID: 2012503783}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 415655056}
   - {fileID: 404407585}
+  - {fileID: 101070164}
   - {fileID: 1449419120}
   - {fileID: 974404316}
   - {fileID: 2032778700}
   - {fileID: 1041161633}
   - {fileID: 371102156}
   - {fileID: 329217822}
+  - {fileID: 459272131}
+  - {fileID: 2012503786}
   - {fileID: 7976212596662436543}
   - {fileID: 1338901711}
   - {fileID: 1763252989}

--- a/Assets/Scripts/Gamemanger/GameManager.cs
+++ b/Assets/Scripts/Gamemanger/GameManager.cs
@@ -19,21 +19,6 @@ public class GameManager : NetworkBehaviour
         }
     }
 
-    // Fonction appelée pour le bouton qui permet de se connecter comme hôte
-    public void LanceCommeHote()
-    {
-        NetworkManager.Singleton.StartHost();
-    }
-
-    // Fonction appelée pour le bouton qui permet de se connecter comme client
-    public void LanceCommeClient()
-    {
-        NetworkManager.Singleton.StartClient();
-    }
-
-    // L'hôte de la partie attend que 2 joueurs soient connectés pour lancer la partie
-    // Seulement l'hôte exécute ce code
-    // Aucune vérification si partie déjà en cours
     void Update()
     {
         if (!IsHost) return;
@@ -45,12 +30,10 @@ public class GameManager : NetworkBehaviour
         }
     }
 
-    // Activation d'une nouvelle partie lorsque 2 joueurs. On appelle la fonction de la balle qui
-    // la place au milieu et qui lui donne une vélocité.
     public void NouvellePartie()
     {
         partieEnCours = true;
-        Puck.instance.LancePuckMilieu();
+        Puck.instance.PlacementPuck(new Vector3(0, 0, 0));
     }
 
    // Fonction appelée par le ScoreManager pour terminer la partie

--- a/Assets/Scripts/Puck.cs
+++ b/Assets/Scripts/Puck.cs
@@ -13,6 +13,9 @@ public class Puck : NetworkBehaviour
     public GameObject Goal1;
     public GameObject Goal2;
 
+    public GameObject puckRespawnPlayer1;
+    public GameObject puckRespawnPlayer2;
+
 
     void Awake()
     {
@@ -37,23 +40,26 @@ public class Puck : NetworkBehaviour
         if (collision.gameObject == Goal1)
         {
             ScoreManager.instance.AugmenteHoteScore();
-            LancePuckMilieu();
+            PlacementPuckGoal(puckRespawnPlayer2.transform.position);
         }
         else if (collision.gameObject == Goal2)
         {
             ScoreManager.instance.AugmenteScoreClient();
-            LancePuckMilieu();
+            PlacementPuckGoal(puckRespawnPlayer1.transform.position);
         }
     }
 
-    public void LancePuckMilieu()
+    public void PlacementPuckGoal(Vector3 puckRespawnPosition)
+    {
+        PlacementPuck(puckRespawnPosition);
+        if (GameManager.instance.partieTerminee) return; 
+        StartCoroutine(NouvellePuck());
+    }
+    public void PlacementPuck(Vector3 puckRespawnPosition)
     {
         GetComponent<NetworkTransform>().Interpolate = false;
-        transform.position = new Vector3(0f, 0f, 0f);
-        GetComponent<Rigidbody>().linearVelocity = new Vector3(0, 0, 0);
-        //if (GameManager.instance.partieTerminee) return; // Il faudra créer cette variable dans le GameManager
-        StartCoroutine(NouvellePuck());
-
+        transform.position = puckRespawnPosition;
+        GetComponent<Rigidbody>().linearVelocity = Vector3.zero;
     }
 
     IEnumerator NouvellePuck()


### PR DESCRIPTION
Introduced puckRespawnPlayer1 and puckRespawnPlayer2 objects in the scene and Puck script. Updated goal collision logic to respawn the puck at the appropriate player's respawn point instead of the center. Refactored GameManager and Puck methods to support new respawn behavior and removed unused host/client connection methods.